### PR TITLE
Feature/#121 add api to get performance status of refract

### DIFF
--- a/server/app/controllers/v1/current_user_refracts_controller.rb
+++ b/server/app/controllers/v1/current_user_refracts_controller.rb
@@ -1,0 +1,14 @@
+module V1
+  class CurrentUserRefractsController < ApplicationController
+    before_action :authenticate_v1_user!
+
+    def show_statuses
+      exist_not_performed_refract = CurrentUserRefract.exists?(
+        user_id: current_v1_user.id,
+        performed_refract: false
+      )
+      performed_refract = !exist_not_performed_refract
+      render json: { performed_refract: performed_refract }, status: :ok
+    end
+  end
+end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -31,5 +31,7 @@ Rails.application.routes.draw do
     post '/refracts/skip',                  to: 'refracts#skip',                               as: :skip
     get  '/refracts/by_me',                 to: 'posts#index_posts_refracted_by_current_user', as: :post_refracted_by_current_user
     get  '/refracts/by_followers',          to: 'posts#index_posts_refracted_by_followers',    as: :post_refracted_by_folowers
+
+    get '/statuses/refracts', to: 'current_user_refracts#show_statuses', as: :refracts_statuses
   end
 end

--- a/server/spec/requests/v1/current_user_refracts_api_spec.rb
+++ b/server/spec/requests/v1/current_user_refracts_api_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe "V1::CurrentUserRefractsApi", type: :request do
+  describe "GET /v1/statuses/refracts - v1/current_user_refracts#show_statuses - Get performance status of refract" do
+    context "when client doesn't have token" do
+      it "returns 401" do
+        get v1_refracts_statuses_path
+        expect(response).to have_http_status(401)
+        expect(response.message).to include('Unauthorized')
+      end
+    end
+
+    context "when client has token" do
+      before do
+        create(:icon)
+      end
+
+      let(:client_user) { create(:user) }
+      let(:headers)     { client_user.create_new_auth_token }
+      let(:follower)    { create(:user) }
+      let(:post)        { create(:post, user_id: client_user.id) }
+
+      context 'when client has no CurrentUserRefracts' do
+        it 'returns 200 and true' do
+          expect(CurrentUserRefract.where(user_id: client_user.id)).not_to exist
+
+          get v1_refracts_statuses_path, headers: headers
+          expect(response).to         have_http_status(200)
+          expect(response.message).to include('OK')
+
+          response_body = JSON.parse(response.body, symbolize_names: true)
+          expect(response_body[:performed_refract]).to eq(true)
+        end
+      end
+
+      context "when client has not performed CurrentUserRefract" do
+        before do
+          CurrentUserRefract.create(
+            user_id: client_user.id,
+            performed_refract: false,
+            post_id: post.id,
+            category: 'like'
+          )
+        end
+
+        it 'returns 200 and false' do
+          expect(CurrentUserRefract.where(user_id: client_user.id, performed_refract: false)).to exist
+
+          get v1_refracts_statuses_path, headers: headers
+          expect(response).to         have_http_status(200)
+          expect(response.message).to include('OK')
+
+          response_body = JSON.parse(response.body, symbolize_names: true)
+          expect(response_body[:performed_refract]).to eq(false)
+        end
+      end
+
+      context "when client doesn't have not performed CurrentUserRefract" do
+        before do
+          CurrentUserRefract.create(
+            user_id: client_user.id,
+            performed_refract: true,
+            post_id: post.id,
+            category: 'like'
+          )
+        end
+
+        it 'returns 200 and true' do
+          expect(CurrentUserRefract.where(user_id: client_user.id, performed_refract: false)).not_to exist
+
+          get v1_refracts_statuses_path, headers: headers
+          expect(response).to         have_http_status(200)
+          expect(response.message).to include('OK')
+
+          response_body = JSON.parse(response.body, symbolize_names: true)
+          expect(response_body[:performed_refract]).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
リフラクトの実施状況を取得するAPIの実装およびテストの実施が完了したため、
ご確認よろしくお願いします。